### PR TITLE
Reduce noisy output from passing assertions

### DIFF
--- a/criterion-hooks.c
+++ b/criterion-hooks.c
@@ -28,9 +28,9 @@ ReportHook(PRE_TEST)(struct criterion_test *test) {
   printf("\n<IT::>%s\n", test->data->description != NULL ? test->data->description : test->name);
 }
 
-static void print_failure_message(const char* message, const char* default_message) {
+static void print_failure_message(const char *message, const char *default_message) {
   printf("<FAILED::>");
-  if(default_message && !(message && *message)) {
+  if (default_message && !(message && *message)) {
     printf("%s", default_message);
     return;
   }
@@ -49,10 +49,10 @@ static void print_failure_message(const char* message, const char* default_messa
 
 // ASSERT: occurs when an assertion is hit
 ReportHook(ASSERT)(struct criterion_assert_stats *stats) {
-        if(stats->passed) {
-          return;
-        }
-        print_failure_message(stats->message, "Assertion failed");
+  if (stats->passed) {
+    return;
+  }
+  print_failure_message(stats->message, "Assertion failed");
 }
 
 // THEORY_FAIL: occurs when a theory iteration fails.
@@ -80,31 +80,26 @@ ReportHook(TEST_CRASH)(struct criterion_test_stats *stats) {
   }
 }
 
-
 static void process_failed_test(struct criterion_test_stats *test) {
-
   // If there is a failed assertion, it most probably got already printed by assertion hook.
   // Test has already been reported as failed.
-  for(struct criterion_assert_stats *assert = test->asserts; assert; assert = assert->next) {
-    if(!assert->passed) {
+  for (struct criterion_assert_stats *assert = test->asserts; assert; assert = assert->next) {
+    if (!assert->passed) {
       return;
     }
   }
-
   print_failure_message(test->message, "Test failed");
 }
 
 // POST_TEST: occurs after a test ends, but before the test finalization.
 ReportHook(POST_TEST)(struct criterion_test_stats *stats) {
-
   if (stats->timed_out) {
     puts("\n<ERROR::>Test Timed Out");
-  } else if(stats->test_status == CR_STATUS_PASSED) {
+  } else if (stats->test_status == CR_STATUS_PASSED) {
     puts("\n<PASSED::>Test Passed");
   } else {
     process_failed_test(stats);
   }
-
   printf("\n<COMPLETEDIN::>%.4f\n", stats->elapsed_time*1000);
 }
 
@@ -122,6 +117,5 @@ ReportHook(POST_SUITE)(struct criterion_suite_stats *stats) {
 }
 
 // POST_ALL: occurs after all the tests are done.
-//
 ReportHook(POST_ALL)(CR_UNUSED struct criterion_global_stats *stats) {
 }

--- a/criterion-hooks.c
+++ b/criterion-hooks.c
@@ -29,7 +29,7 @@ ReportHook(PRE_TEST)(struct criterion_test *test) {
 }
 
 static void print_failure_message(const char *message, const char *default_message) {
-  printf("<FAILED::>");
+  printf("\n<FAILED::>");
   if (default_message && !(message && *message)) {
     printf("%s", default_message);
     return;


### PR DESCRIPTION
Move `<PASSED::>` from `ASSERT` hook to `POST_TEST` hook.

Kumite with tests report created by current reporter: https://www.codewars.com/kumite/62288f7e66b26a0056b9ea69
Kumite with a test report from my reporter: https://www.codewars.com/kumite/62288eba1eb5d90048fd7f52